### PR TITLE
Correct markdown lints

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,8 +1,8 @@
-## CC0 1.0 Universal Public Domain
+# CC0 1.0 Universal Public Domain
 
 This project constitutes a work of the United States Government and is not subject to domestic copyright protection under 17 USC § 105. Additionally, we waive copyright and related rights in the work worldwide through the [CC0 1.0 Universal public domain dedication](https://creativecommons.org/publicdomain/zero/1.0/).
 
-All contributions to this project will be released under the CC0 dedication. By submitting a requirement, issue or pull request, you are agreeing to comply with this waiver of copyright interest. 
+All contributions to this project will be released under the CC0 dedication. By submitting a requirement, issue or pull request, you are agreeing to comply with this waiver of copyright interest.
 
 ## Other Information
 

--- a/README.md
+++ b/README.md
@@ -1,19 +1,20 @@
 # [DCAT-US Schema v3.0](https://doi-do.github.io/dcat-us/)
-The FAIRness Project is introducing a draft update to the Data Catalog (DCAT) standard for the United States!  This update, “DCAT-US v3.0 Schema,” builds upon the requirements we received from agencies as well as data creators, providers, and users, Data Inventory statutory requirements, and the lessons learned over ten years of successful implementation of the Project Open Data Metadata Standard (DCAT-US v1.1) used by Data.gov.    
 
-We need your help to review and comment on this draft so that it meets agencies’ data inventory needs and those of cross-government programs like Data.gov, GeoPlatform, and the Standard Application Process Portal.   
+The FAIRness Project is introducing a draft update to the Data Catalog (DCAT) standard for the United States!  This update, “DCAT-US v3.0 Schema,” builds upon the requirements we received from agencies as well as data creators, providers, and users, Data Inventory statutory requirements, and the lessons learned over ten years of successful implementation of the Project Open Data Metadata Standard (DCAT-US v1.1) used by Data.gov.
 
-Once approved and implemented, the update will improve the FAIRness, or Findability, Accessibility, Interoperability, and Reusability of all types of federal data.  DCAT-US v3 will provide a *single* metadata standard able to support most requirements for documentation of business, technical, statistical, and geospatial data consistently. 
+We need your help to review and comment on this draft so that it meets agencies’ data inventory needs and those of cross-government programs like Data.gov, GeoPlatform, and the Standard Application Process Portal.
 
-Key features of the [DCAT-US v3.0 Schema](https://doi-do.github.io/dcat-us/) are: 
+Once approved and implemented, the update will improve the FAIRness, or Findability, Accessibility, Interoperability, and Reusability of all types of federal data.  DCAT-US v3 will provide a *single* metadata standard able to support most requirements for documentation of business, technical, statistical, and geospatial data consistently.
+
+Key features of the [DCAT-US v3.0 Schema](https://doi-do.github.io/dcat-us/) are:
 
 1. DCAT-US v3 is not a “new” standard; it is a “profile” of or implementation of the [World Wide Web Consortium’s (W3C) DCAT standard]( https://www.w3.org/TR/vocab-dcat-3/).
-1. DCAT-US v3 is compatible with existing DCAT v1.1 metadata.  No translation is required to implement the new schema.  New metadata elements are added, but there are no major changes to existing elements. 
-1. DCAT-US v3 supports new and updated controlled vocabularies, allowing for consistently naming items like federal agencies, file formats, and units of measure. 
-1. DCAT-US v3 will overcome the limitations of DCAT v1.1 when documenting geospatial data, eliminating the need for a separate federal standard for this subset of data. 
+1. DCAT-US v3 is compatible with existing DCAT v1.1 metadata.  No translation is required to implement the new schema.  New metadata elements are added, but there are no major changes to existing elements.
+1. DCAT-US v3 supports new and updated controlled vocabularies, allowing for consistently naming items like federal agencies, file formats, and units of measure.
+1. DCAT-US v3 will overcome the limitations of DCAT v1.1 when documenting geospatial data, eliminating the need for a separate federal standard for this subset of data.
 1. DCAT-US v3 follows a similar approach to European metadata DCAT-AP; vendor support is already in place, with additional support underway.  
 
-Please review the [DCAT-US v3.0 Schema](https://doi-do.github.io/dcat-us/) and the material found in the links below, and provide feedback to help make this standard as useful as possible to you and the broader federal data user community. 
+Please review the [DCAT-US v3.0 Schema](https://doi-do.github.io/dcat-us/) and the material found in the links below, and provide feedback to help make this standard as useful as possible to you and the broader federal data user community.
 
 1. [Project Wiki](https://github.com/DOI-DO/dcat-us/wiki)
 1. [Project Overview](https://github.com/DOI-DO/dcat-us/wiki/Project-Overview)
@@ -26,5 +27,3 @@ Please review the [DCAT-US v3.0 Schema](https://doi-do.github.io/dcat-us/) and t
 The project is a public domain work and is not subject to domestic or international copyright protection. See [the license file](LICENSE.md) for additional information.
 
 Members of the public and US government employees who wish to contribute are encouraged to do so, but by contributing, dedicate their work to the public domain and waive all rights to their contribution under the terms of the [CC0 Public Domain Dedication](http://creativecommons.org/publicdomain/zero/1.0/).
-
-


### PR DESCRIPTION
Using markdownlint-cli v0.37.0

```
README.md:1 MD022/blanks-around-headings/blanks-around-headers Headings should be surrounded by blank lines [Expected: 1; Actual: 0; Below] [Context: "# [DCAT-US Schema v3.0](https://doi-do.github.io/dcat-us/)"]
README.md:2:433 MD009/no-trailing-spaces Trailing spaces [Expected: 0 or 2; Actual: 4]
README.md:4:214 MD009/no-trailing-spaces Trailing spaces [Expected: 0 or 2; Actual: 3]
README.md:6:341 MD009/no-trailing-spaces Trailing spaces [Expected: 0 or 2; Actual: 1]
README.md:8:82 MD009/no-trailing-spaces Trailing spaces [Expected: 0 or 2; Actual: 1]
README.md:11:206 MD009/no-trailing-spaces Trailing spaces [Expected: 0 or 2; Actual: 1]
README.md:12:162 MD009/no-trailing-spaces Trailing spaces [Expected: 0 or 2; Actual: 1]
README.md:13:169 MD009/no-trailing-spaces Trailing spaces [Expected: 0 or 2; Actual: 1]
README.md:16:240 MD009/no-trailing-spaces Trailing spaces [Expected: 0 or 2; Actual: 1]
README.md:30 MD012/no-multiple-blanks Multiple consecutive blank lines [Expected: 1; Actual: 2]
README.md:31 MD012/no-multiple-blanks Multiple consecutive blank lines [Expected: 1; Actual: 3]
LICENSE.md:1 MD041/first-line-heading/first-line-h1 First line in a file should be a top-level heading [Context: "## CC0 1.0 Universal Public Do..."]
LICENSE.md:5:196 MD009/no-trailing-spaces Trailing spaces [Expected: 0 or 2; Actual: 1]
```