### PR TITLE
Issue 139 (partial): Fix DASH shape-component usage by copying original shape

### DIFF
--- a/shacl/dcat-us_3.0_shacl_shapes.ttl
+++ b/shacl/dcat-us_3.0_shacl_shapes.ttl
@@ -3558,5 +3558,19 @@ dcat-us-shp:GeometryAsWKTorGMLorGeoJSON rdf:first ( gsp:wktLiteral gsp:gmlLitera
 
 dcat-us-shp:DateOrDateTimeOrYearOrYearMonth rdf:first ( xsd:date xsd:dateTime xsd:gYear xsd:gYearMonth ) .
 
-dash:StringOrLangString rdf:first ( xsd:string rdf:langString ) .
+dash:StringOrLangString
+  a rdf:List ;
+  rdf:first [
+      sh:datatype xsd:string ;
+    ] ;
+  rdf:rest (
+      [
+        sh:datatype rdf:langString ;
+      ]
+    ) ;
+  rdfs:comment "An rdf:List that can be used in property constraints as value for sh:or to indicate that all values of a property must be either xsd:string or rdf:langString." ;
+  rdfs:label "String or langString" ;
+  rdfs:isDefinedBy <http://datashapes.org/dash> ;
+  rdfs:comment "This shape was copied into dcat-us_3.0_shacl_shapes.ttl on 2023-11-21."@en ;
+.
 


### PR DESCRIPTION
The patch(es) in this PR include documentation for their changes.

This PR fixes some, but not all, of the SHACL-SHACL validation issues in #139 .  It includes a suggestion for how to fix some of the other issues pertaining to the `sh:or`-linked `rdf:List`s.  I'm happy to add follow-on patches to fix other `rdf:List` issues, but I wanted to pause for input from the maintainers before doing so.

I believe this PR can be merged without negative impact.